### PR TITLE
chore(nix): update flake.lock and repo info

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Latest Better Blur versions for previous Plasma releases:
       nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
 
       kwin-effects-forceblur = {
-        url = "github:taj-ny/kwin-effects-forceblur";
+        url = "github:can1357/kde-blur";
         inputs.nixpkgs.follows = "nixpkgs";
       };
     };

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1730200266,
-        "narHash": "sha256-l253w0XMT8nWHGXuXqyiIC/bMvh1VRszGXgdpQlfhvU=",
+        "lastModified": 1777268161,
+        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "807e9154dcb16384b1b765ebe9cd2bba2ac287fd",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {

--- a/nix/package-x11.nix
+++ b/nix/package-x11.nix
@@ -27,6 +27,6 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Fork of the KWin Blur effect for KDE Plasma 6 with additional features (including force blur) and bug fixes";
     license = licenses.gpl3;
-    homepage = "https://github.com/taj-ny/kwin-effects-forceblur";
+    homepage = "https://github.com/can1357/kde-blur";
   };
 }

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -27,6 +27,6 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Fork of the KWin Blur effect for KDE Plasma 6 with additional features (including force blur) and bug fixes";
     license = licenses.gpl3;
-    homepage = "https://github.com/taj-ny/kwin-effects-forceblur";
+    homepage = "https://github.com/can1357/kde-blur";
   };
 }


### PR DESCRIPTION
Using the built package on my system caused major artifacting (up to date nixos-instable) but this at least fixes the old repo references and should be a solution to the confusion of #5